### PR TITLE
fixed configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Create Build
+name: 🔧 Create Build
 
 on:
   pull_request:
@@ -8,13 +8,14 @@ on:
 
 jobs:
   check:
+    name: Create build 🔧
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
+      - name: Checkout repo ✔️
+        uses: actions/checkout@v3
 
-      - name: Use Node
+      - name: Use Node ⚡
         uses: actions/setup-node@v1
         with:
           node-version: '16.x'

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,25 +1,25 @@
-name: Bump Version
+name: ⬆️ Bump Version
 
 on:
   push:
     branches:
-      - 'main'
+      - main
 
 jobs:
   bump-version:
-    name: 'Bump Version on master'
+    name: Bump Version ⬆️
     runs-on: ubuntu-latest
 
     steps:
-      - name: 'Checkout source code'
-        uses: 'actions/checkout@v2'
+      - name: Checkout repo ✔️
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
-      - name: 'cat package.json'
+      - name: cat package.json
         run: cat ./package.json
 
-      - name: 'Automated Version Bump'
+      - name: Automated Version Bump
         id: version-bump
         uses: 'phips28/gh-action-bump-version@master'
         with:
@@ -27,10 +27,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'cat package.json'
+      - name: cat package.json
         run: cat ./package.json
 
-      - name: 'Output Step'
+      - name: Output Step ✨
         env:
           NEW_TAG: ${{ steps.version-bump.outputs.newTag }}
         run: echo "new tag $NEW_TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
-name: Publish
+name: 🚀 Publish
 
 on:
   workflow_run:
-    workflows: [Bump Version]
+    workflows: [⬆️ Bump Version]
     types:
       - completed
 
@@ -10,11 +10,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout repo 🔧
         uses: actions/checkout@v3
 
-      - name: Use Node
-        uses: actions/setup-node@v2
+      - name: Use Node ⚡
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saleshandy/icons",
-  "version": "1.1.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saleshandy/icons",
-      "version": "1.1.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.22.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saleshandy/icons",
-  "version": "1.1.0",
+  "version": "0.0.1",
   "description": "Saleshandy Icons Library",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
1. Fixed the GitHub workflow warning 

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v2.

2. Reconfigured the version in the `package.json` to `v0.0.1`